### PR TITLE
[0221] feat: 문서 파싱문제 해결

### DIFF
--- a/maruegg/views/pdf_upload_views.py
+++ b/maruegg/views/pdf_upload_views.py
@@ -162,7 +162,7 @@ def extract_toc(pdf_document, page_gap):
 
     for idx, page in enumerate(pdf_document):
         text = page['text']
-        if "CONTENTS" in text:
+        if "CONTENTS" in text or "Contents" in text:
             contentPage = idx + 1
             pdf_document[idx]['metadata']['title'] = "CONTENTS"
             break


### PR DESCRIPTION
### 문제
새로운 정시 파일(추가 정시 모집요강) 업로드 했는데 자동 파싱 및 메타데이터 조정 로직 부분에서 오류가 발생함.

### 발생이유
추가 정시 모집요강 파일은 목차 구조가 바뀌어서 목차 인식이 불가능하여 오류 발생한 것.

### 해결
자동 파싱 및 메타데이터 조정 로직에서 목차 페이지로 인식될 수 있게 추가 예외처리 하였음.